### PR TITLE
Add Open Search protocol for Zotero

### DIFF
--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<ShortName>oaDOI Lookup</ShortName>
+<Description>oaDOI Resolver for Zotero</Description>
+<Image width="64" height="64" type="image/png">http://oadoi.org/static/img/favicon.png</Image>
+<Url type="text/html" method="GET"
+  xmlns:z="http://www.zotero.org/namespaces/openSearch#" 
+  template="http://oadoi.org/{z:DOI}"/>
+</OpenSearchDescription>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0-rc4/angular-material.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/agate.min.css">
+    <link rel="search" type="application/x-openurl-opensearchdescription+xml" title="oaDOI Lookup" href="/static/opensearch.xml">
 
     <link href="/static/main.css" rel="stylesheet">
     <link rel="icon" type="image/ico" href="/static/img/favicon.png" />


### PR DESCRIPTION
This adds a search possibility in opensearch.xml
which will be linked from your main page. It allows
Zotero users to add a oaDOI search as a lookup engine.