### PR TITLE
Switch to absolute link for opensearch.xml

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.0-rc4/angular-material.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/agate.min.css">
-    <link rel="search" type="application/x-openurl-opensearchdescription+xml" title="oaDOI Lookup" href="/static/opensearch.xml">
+    <link rel="search" type="application/x-openurl-opensearchdescription+xml" title="oaDOI Lookup" href="http://oadoi.org/static/opensearch.xml">
 
     <link href="/static/main.css" rel="stylesheet">
     <link rel="icon" type="image/ico" href="/static/img/favicon.png" />


### PR DESCRIPTION
It was indicated by @adam3smith that one has to use absolute links here, in order to work properly with Zotero.